### PR TITLE
Fix demo-watch gulp task

### DIFF
--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -32,7 +32,7 @@ gulp.task("demo-sass", function() {
 });
 
 gulp.task("demo-watch", function() {
-  gulp.watch("./src/sass/**/*.scss", ["demo-sass"]);
+  gulp.watch("./src/styles/**/*.scss", ["demo-sass"]);
   gulp.watch("./demo/main.scss", ["demo-sass"]);
 });
 


### PR DESCRIPTION
Sets it to watch the `src/styles` directory instead of `src/sass`